### PR TITLE
実行時間を短縮するために lambda の割り当てメモリを増やす。

### DIFF
--- a/.chalice/config.json
+++ b/.chalice/config.json
@@ -7,7 +7,8 @@
       "environment_variables": {
         "TZ": "Asia/Tokyo"
       },
-      "lambda_timeout": 120
+      "lambda_timeout": 120,
+      "lambda_memory_size": 512
     }
   }
 }


### PR DESCRIPTION
30秒を超えると API Gateway のタイムアウトが発生する。
それで Lambda の実行に支障が出るわけではないが、API を叩く側からすると結果が成功なのか失敗なのか不明なので困る。

Lambda の割り当てメモリを増やすことで実行時間を短くできることが分かったので、そのようにする。