### PR TITLE
ポリシーファイル自動生成を無効にする。

### DIFF
--- a/.chalice/config.json
+++ b/.chalice/config.json
@@ -4,6 +4,7 @@
   "stages": {
     "dev": {
       "api_gateway_stage": "api",
+      "autogen_policy": false,
       "environment_variables": {
         "TZ": "Asia/Tokyo"
       },

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: deploy lock
 
 deploy:
-	chalice deploy --no-autogen-policy
+	chalice deploy
 
 lock:
 	pipenv lock -r > requirements.txt


### PR DESCRIPTION
GitHub Actions でデプロイするときはコマンドラインオプションが使えないので設定ファイルに明示が必要だった。